### PR TITLE
Add a way to hide all but the last layer

### DIFF
--- a/src/Command/Components.elm
+++ b/src/Command/Components.elm
@@ -5,6 +5,7 @@ module Command.Components exposing (
       , incrementerDefaults
       , toggle
       , choice
+      , textButtonGroup
     )
 
 import Html.Styled as HS
@@ -116,4 +117,29 @@ choice label choices
                     HS.option [HSE.onClick msg] [HS.text choiceText]
                 )
                 choices
+    ]
+
+{-| A group of buttons with text labels and a header -}
+textButtonGroup
+    : String  -- ^ Header text
+    -> List ( String, msg )  -- ^ List of (label, message) pairs
+    -> List (HS.Html msg)
+textButtonGroup header buttons
+    = [
+        HS.div [ HSA.css [Css.marginTop (Css.px 10)] ]
+            ( HS.h4 [] [ HS.text header ]
+                :: List.map
+                    (\(label, msg) ->
+                        HS.button
+                            [
+                                HSA.css [
+                                    Css.marginRight (Css.px 5)
+                                  , Css.marginLeft (Css.px 5)
+                                ]
+                              , HSE.onClick msg
+                            ]
+                            [ HS.text label ]
+                    )
+                    buttons
+            )
     ]

--- a/src/Space/Content.elm
+++ b/src/Space/Content.elm
@@ -13,6 +13,7 @@ module Space.Content exposing (
     )
 
 import Svg.Styled as S
+import Set
 
 import Space.TreeID as ID
 import Space.Shape as Shape
@@ -121,10 +122,14 @@ appendIterShapes mode contents
         iterShapes
             = List.map makeIterShape
                 <| IterFrame.iterateShapes mode iterFrameDefs shapeDefs
+        allShapes
+            = if Set.member 0 mode.hiddenLayers
+                then iterShapes
+                else shapes ++ iterShapes
     in
         if mode.showIterFrames
-        then shapes ++ iterShapes ++ iterFrames
-        else shapes ++ iterShapes
+        then allShapes ++ iterFrames
+        else allShapes
 
 
 getIterFrameDefs : List Content -> (List Content, List (ID.TreeID, IterFrame.Def))

--- a/src/Space/IterFrame.elm
+++ b/src/Space/IterFrame.elm
@@ -110,6 +110,7 @@ type alias Mode
       , showIterFrames : Bool
         -- Layers to hide
         -- Convention: 1 is the first iteration
+        --   0 represents the base shapes
       , hiddenLayers : Set.Set Int
     }
 

--- a/src/Space/IterFrame.elm
+++ b/src/Space/IterFrame.elm
@@ -12,6 +12,7 @@ module Space.IterFrame exposing (
 import Svg.Styled as S
 import Svg.Styled.Attributes as SA
 import List
+import Set
 import Color as C
 
 import Geometry as G
@@ -107,13 +108,14 @@ type alias Mode
         depth: Int
       , hueShift : Float
       , showIterFrames : Bool
+      , hiddenLayers : Set.Set Int
     }
 
 {-| Default mode for initializing -}
 initMode
     : Mode
 initMode
-    = {depth = 6, hueShift = (0.618034 * 8/7), showIterFrames = True}
+    = {depth = 6, hueShift = (0.618034 * 8/7), showIterFrames = True, hiddenLayers = Set.empty}
 
 iterateShapes
     : Mode

--- a/tests/Space/IterFrameSpec.elm
+++ b/tests/Space/IterFrameSpec.elm
@@ -1,0 +1,74 @@
+module Space.IterFrameSpec exposing (suite)
+
+import Test as T
+import Expect as E
+import Set
+import Color
+
+import Space.IterFrame as IterFrame
+import Space.TreeID as ID
+import Space.Shape as Shape
+import Geometry as G
+
+suite : T.Test
+suite = T.describe "module Space.IterFrame" [
+        iterationTests
+    ]
+
+iterationTests : T.Test
+iterationTests = T.describe "iteration functionality" [
+        basicIteration
+      , hiddenLayerTests
+    ]
+
+basicIteration : T.Test
+basicIteration = T.test "iterateShapes produces expected number of shapes with no hidden layers" <|
+    \_ ->
+        let
+            mode = { initMode | depth = 3 }
+            startShape = (ID.Trunk "start", dummyShape)
+            iterFrame = (ID.Trunk "f1", dummyFrame)
+            result = IterFrame.iterateShapes mode [iterFrame] [startShape]
+        in
+            E.equal (List.length result) 3  -- One shape for each depth
+
+hiddenLayerTests : T.Test
+hiddenLayerTests = T.describe "hidden layer functionality" [
+        T.test "hiding middle layer removes those shapes" <|
+            \_ ->
+                let
+                    mode = { initMode | 
+                        depth = 3,
+                        hiddenLayers = Set.singleton 1  -- Hide middle layer
+                        }
+                    startShape = (ID.Trunk "start", dummyShape)
+                    iterFrame = (ID.Trunk "f1", dummyFrame)
+                    result = IterFrame.iterateShapes mode [iterFrame] [startShape]
+                in
+                    E.equal (List.length result) 2  -- First and last layer only
+      , T.test "hiding all layers produces empty list" <|
+            \_ ->
+                let
+                    mode = { initMode | 
+                        depth = 3,
+                        hiddenLayers = Set.fromList [1, 2, 3]
+                        }
+                    startShape = (ID.Trunk "start", dummyShape)
+                    iterFrame = (ID.Trunk "f1", dummyFrame)
+                    result = IterFrame.iterateShapes mode [iterFrame] [startShape]
+                in
+                    E.equal result []
+    ]
+
+-- Helper definitions for testing
+initMode : IterFrame.Mode
+initMode = IterFrame.initMode
+
+dummyShape : Shape.Def
+dummyShape = 
+    { fill = Color.black
+    , geoDef = G.Polygon [G.point 0 0, G.point 1 0, G.point 0 1]
+    }
+
+dummyFrame : IterFrame.Def
+dummyFrame = IterFrame.identityDef


### PR DESCRIPTION
In the code, any layer may be selectively hidden by specifying a set of indices to hide.

For now, the only controls provided are for showing all layers and just the last one. Figuring out the UI to exclude arbitrary layers will be a bit complex, and it may not add much to the experience, so I'm saying this resolves #2. Add a new issue if there's a reason to toggle each layer independently.