### PR TITLE
Fix showing last layer while changing iteration depth

### DIFF
--- a/src/Space/Content.elm
+++ b/src/Space/Content.elm
@@ -123,7 +123,7 @@ appendIterShapes mode contents
             = List.map makeIterShape
                 <| IterFrame.iterateShapes mode iterFrameDefs shapeDefs
         allShapes
-            = if Set.member 0 mode.hiddenLayers
+            = if mode.onlyShowLastLayer && (mode.depth > 0)
                 then iterShapes
                 else shapes ++ iterShapes
     in


### PR DESCRIPTION
Fixes #6

## Change hidden layer implementation

While working on the fix, fuzz testing revealed that `IterFrame.Mode`'s `hiddenLayers` set couldn't properly distinguish between "show all layers" and "show only last layer" when depth was zero. To resolve this ambiguity, I replaced the `hiddenLayers` set with a dedicated `onlyShowLastLayer` flag.

The shape iteration logic continues to use a Set internally for tracking hidden layers, preserving the ability to add more granular layer visibility control in the future if needed.

### Changes
- Replaced `hiddenLayers` with `onlyShowLastLayer` flag
- Updated `IterFrame` functions to work with new flag
- Added corresponding tests