### PR TITLE
Add basic tutorial

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,11 +9,6 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <!-- Static HTML content -->
-  <header>
-    <h1>Fractal Play</h1>
-  </header>
-
   <!-- Elm will render inside this div -->
   <div id="fractal-play"></div>
 

--- a/public/style.css
+++ b/public/style.css
@@ -2,10 +2,6 @@ body {
     font-family: 'Nunito', sans-serif;
 }
 
-h1 {
-    margin-left: 2rem;
-}
-
 .command-label {
     margin-top: 1.5rem;
     margin-bottom: 0.5rem;

--- a/public/style.css
+++ b/public/style.css
@@ -22,3 +22,7 @@ select {
     border-radius: 0.2rem;
     border: none;
 }
+
+.control-background {
+    background-color: #d0f9fe;
+}

--- a/src/Command/Components.elm
+++ b/src/Command/Components.elm
@@ -34,6 +34,8 @@ incrementer settings sendIncrement current
       , HS.span [] [
             HS.button
                 (
+                    HSA.class "control-background"
+                    ::
                     if valueAtLimit settings.max current
                     then []
                     else [HSE.onClick <| sendIncrement 1]
@@ -42,6 +44,8 @@ incrementer settings sendIncrement current
           , numberLabel current
           , HS.button
                 (
+                    HSA.class "control-background"
+                    ::
                     if valueAtLimit settings.min current
                     then []
                     else [HSE.onClick <| sendIncrement (-1)]
@@ -118,7 +122,7 @@ choice
 choice label choices
     = [
         commandLabel label
-      , HS.select []
+      , HS.select [HSA.class "control-background"]
             <| List.map
                 (\(choiceText, msg) ->
                     HS.option [HSE.onClick msg] [HS.text choiceText]
@@ -139,7 +143,8 @@ textButtonGroup header buttons
                     (\(label, msg) ->
                         HS.button
                             [
-                                HSA.css [
+                                HSA.class "control-background"
+                              , HSA.css [
                                     Css.marginRight (Css.px 5)
                                   , Css.marginLeft (Css.px 5)
                                 ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -7,6 +7,7 @@ import Browser as B
 
 import Space
 import SpaceCommand as SC
+import Tutorial
 
 main : Program () Space.Model SC.Message
 main = B.sandbox {
@@ -18,10 +19,20 @@ main = B.sandbox {
 viewWithHeader : Space.Model -> HS.Html SC.Message
 viewWithHeader model =
     HS.div []
-        [ HS.header []
+        [ HS.header 
+            [ HSA.css 
+                [ Css.displayFlex
+                , Css.alignItems Css.center
+                , Css.property "gap" "2rem"
+                , Css.justifyContent Css.spaceBetween
+                , Css.paddingLeft (Css.rem 2)
+                , Css.paddingRight (Css.rem 2)
+                ]
+            ]
             [ HS.h1 
-                [ HSA.css [ Css.marginLeft (Css.rem 2) ] ]
+                [ HSA.css [Css.margin2 (Css.rem 1) (Css.rem 0) ] ]
                 [ HS.text "Fractal Play" ]
+            , Tutorial.view
             ]
         , SC.view model
         ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -16,6 +16,9 @@ main = B.sandbox {
     }
 
 
+{-| Main view, including header and tutorial.
+    This is defined here because things like the header should be owned by Main.
+ -}
 viewWithHeader : Tutorial.WrapModel -> HS.Html Tutorial.WrapMessage
 viewWithHeader model =
     HS.div []
@@ -37,6 +40,8 @@ viewWithHeader model =
         , HS.map Tutorial.SpaceMessage <| SC.view model.space
         ]
 
+
+{-| Update that redirects messages to the right component. -}
 update : Tutorial.WrapMessage -> Tutorial.WrapModel -> Tutorial.WrapModel
 update message model
   = case message of

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -9,14 +9,25 @@ import Space
 import SpaceCommand as SC
 import Tutorial
 
-main : Program () Space.Model SC.Message
+main : Program () Model SC.Message
 main = B.sandbox {
-        init = SC.init
+        init = init
       , view = HS.toUnstyled << viewWithHeader
-      , update = SC.update
+      , update = update
     }
 
-viewWithHeader : Space.Model -> HS.Html SC.Message
+type alias Model
+    = { space : Space.Model
+      , tutorial : Tutorial.Model
+    }
+
+init : Model
+init = {
+        space = SC.init
+      , tutorial = Tutorial.init
+    }
+
+viewWithHeader : Model -> HS.Html SC.Message
 viewWithHeader model =
     HS.div []
         [ HS.header 
@@ -32,7 +43,13 @@ viewWithHeader model =
             [ HS.h1 
                 [ HSA.css [Css.margin2 (Css.rem 1) (Css.rem 0) ] ]
                 [ HS.text "Fractal Play" ]
-            , Tutorial.view
+            , Tutorial.view model.tutorial
             ]
-        , SC.view model
+        , SC.view model.space
         ]
+
+update : SC.Message -> Model -> Model
+update message model
+  = { model
+        | space = SC.update message model.space
+  }

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -5,33 +5,22 @@ import Html.Styled.Attributes as HSA
 import Css
 import Browser as B
 
-import Space
 import SpaceCommand as SC
 import Tutorial
 
-main : Program () Model SC.Message
+main : Program () Tutorial.WrapModel Tutorial.WrapMessage
 main = B.sandbox {
-        init = init
+        init = Tutorial.wrapInit
       , view = HS.toUnstyled << viewWithHeader
       , update = update
     }
 
-type alias Model
-    = { space : Space.Model
-      , tutorial : Tutorial.Model
-    }
 
-init : Model
-init = {
-        space = SC.init
-      , tutorial = Tutorial.init
-    }
-
-viewWithHeader : Model -> HS.Html SC.Message
+viewWithHeader : Tutorial.WrapModel -> HS.Html Tutorial.WrapMessage
 viewWithHeader model =
     HS.div []
-        [ HS.header 
-            [ HSA.css 
+        [ HS.header
+            [ HSA.css
                 [ Css.displayFlex
                 , Css.alignItems Css.center
                 , Css.property "gap" "2rem"
@@ -40,16 +29,16 @@ viewWithHeader model =
                 , Css.paddingRight (Css.rem 2)
                 ]
             ]
-            [ HS.h1 
+            [ HS.h1
                 [ HSA.css [Css.margin2 (Css.rem 1) (Css.rem 0) ] ]
                 [ HS.text "Fractal Play" ]
-            , Tutorial.view model.tutorial
+            , HS.map Tutorial.TutorialMessage <| Tutorial.view model.tutorial
             ]
-        , SC.view model.space
+        , HS.map Tutorial.SpaceMessage <| SC.view model.space
         ]
 
-update : SC.Message -> Model -> Model
+update : Tutorial.WrapMessage -> Tutorial.WrapModel -> Tutorial.WrapModel
 update message model
-  = { model
-        | space = SC.update message model.space
-  }
+  = case message of
+        Tutorial.SpaceMessage msg -> { model | space = SC.update msg model.space }
+        Tutorial.TutorialMessage msg -> Tutorial.update msg model

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,6 +1,8 @@
 module Main exposing ( main )
 
 import Html.Styled as HS
+import Html.Styled.Attributes as HSA
+import Css
 import Browser as B
 
 import Space
@@ -9,6 +11,17 @@ import SpaceCommand as SC
 main : Program () Space.Model SC.Message
 main = B.sandbox {
         init = SC.init
-      , view = HS.toUnstyled << SC.view
+      , view = HS.toUnstyled << viewWithHeader
       , update = SC.update
     }
+
+viewWithHeader : Space.Model -> HS.Html SC.Message
+viewWithHeader model =
+    HS.div []
+        [ HS.header []
+            [ HS.h1 
+                [ HSA.css [ Css.marginLeft (Css.rem 2) ] ]
+                [ HS.text "Fractal Play" ]
+            ]
+        , SC.view model
+        ]

--- a/src/Space/Content.elm
+++ b/src/Space/Content.elm
@@ -13,7 +13,6 @@ module Space.Content exposing (
     )
 
 import Svg.Styled as S
-import Set
 
 import Space.TreeID as ID
 import Space.Shape as Shape

--- a/src/Tutorial.elm
+++ b/src/Tutorial.elm
@@ -1,15 +1,22 @@
 module Tutorial exposing (
         view
       , Model
-      , init
+      , WrapModel
+      , wrapInit
+      , Message(..)
+      , WrapMessage(..)
+      , update
     )
 
 import Html.Styled as HS
 import Html.Styled.Attributes as HSA
+import Html.Styled.Events as HSE
 import Css
 import Maybe
 
 import Tutorial.Sequence as TS
+import Space
+import SpaceCommand as SC
 
 type alias Model
     = { sequence : TS.Sequence }
@@ -17,7 +24,31 @@ type alias Model
 init : Model
 init = { sequence = TS.init }
 
-view : Model -> HS.Html msg
+modelLiftSequence
+    : (TS.Sequence -> TS.Sequence)
+   -> (Model -> Model)
+modelLiftSequence f model
+    = { model | sequence = f model.sequence }
+
+type alias WrapModel
+    = {
+        space : Space.Model
+      , tutorial : Model
+    }
+
+wrapLiftTutorial
+    : (Model -> Model)
+   -> (WrapModel -> WrapModel)
+wrapLiftTutorial f model
+    = { model | tutorial = f model.tutorial }
+
+wrapInit : WrapModel
+wrapInit = {
+        space = SC.init
+      , tutorial = init
+    }
+
+view : Model -> HS.Html Message
 view model
     = let
         current = TS.getCurrent model.sequence
@@ -30,7 +61,7 @@ view model
       in HS.div
         [
             HSA.class "control-background"
-            , HSA.css
+          , HSA.css
                 [ Css.padding (Css.rem 1)
                 , Css.borderRadius (Css.rem 0.5)
                 , Css.maxWidth (Css.px 400)
@@ -38,5 +69,18 @@ view model
                     then Css.display Css.block
                     else Css.display Css.none)
                 ]
+          , HSE.onClick Advance
         ]
         [ message ]
+
+type Message
+    = Advance
+
+type WrapMessage
+    = SpaceMessage SC.Message
+    | TutorialMessage Message
+
+update : Message -> WrapModel -> WrapModel
+update message
+    = case message of
+        Advance -> wrapLiftTutorial (modelLiftSequence TS.advance)

--- a/src/Tutorial.elm
+++ b/src/Tutorial.elm
@@ -1,0 +1,24 @@
+module Tutorial exposing (
+        view
+    )
+
+import Html.Styled as HS
+import Html.Styled.Attributes as HSA
+import Css
+
+
+view : HS.Html msg
+view
+    = HS.div 
+        [ HSA.css
+            [ Css.padding (Css.rem 1)
+            , Css.backgroundColor (Css.hex "f0f0f0")
+            , Css.borderRadius (Css.rem 0.5)
+            , Css.maxWidth (Css.px 400)
+            ]
+        ]
+        [ HS.text (messageDisplay) ]
+
+messageDisplay : String
+messageDisplay
+    = "Click to start tutorial" 

--- a/src/Tutorial.elm
+++ b/src/Tutorial.elm
@@ -78,7 +78,8 @@ view model
                 ]
           , HSE.onClick Advance
         ]
-        [ message ]
+        -- map for type only
+        [ HS.map (always Advance) message ]
 
 {-| Message for tutorial. -}
 type Message

--- a/src/Tutorial.elm
+++ b/src/Tutorial.elm
@@ -10,12 +10,13 @@ import Css
 view : HS.Html msg
 view
     = HS.div 
-        [ HSA.css
-            [ Css.padding (Css.rem 1)
-            , Css.backgroundColor (Css.hex "f0f0f0")
-            , Css.borderRadius (Css.rem 0.5)
-            , Css.maxWidth (Css.px 400)
-            ]
+        [ 
+            HSA.class "control-background"
+            , HSA.css
+                [ Css.padding (Css.rem 1)
+                , Css.borderRadius (Css.rem 0.5)
+                , Css.maxWidth (Css.px 400)
+                ]
         ]
         [ HS.text (messageDisplay) ]
 

--- a/src/Tutorial.elm
+++ b/src/Tutorial.elm
@@ -71,7 +71,7 @@ view model
           , HSA.css
                 [ Css.padding (Css.rem 1)
                 , Css.borderRadius (Css.rem 0.5)
-                , Css.maxWidth (Css.px 400)
+                , Css.maxWidth (Css.rem 80)
                 , (if shouldDisplay
                     then Css.display Css.block
                     else Css.display Css.none)

--- a/src/Tutorial.elm
+++ b/src/Tutorial.elm
@@ -1,25 +1,42 @@
 module Tutorial exposing (
         view
+      , Model
+      , init
     )
 
 import Html.Styled as HS
 import Html.Styled.Attributes as HSA
 import Css
+import Maybe
 
+import Tutorial.Sequence as TS
 
-view : HS.Html msg
-view
-    = HS.div 
-        [ 
+type alias Model
+    = { sequence : TS.Sequence }
+
+init : Model
+init = { sequence = TS.init }
+
+view : Model -> HS.Html msg
+view model
+    = let
+        current = TS.getCurrent model.sequence
+        message = Maybe.withDefault
+            (HS.text "")
+            (Maybe.map TS.getMessage current)
+        shouldDisplay = case current of
+            Just _ -> True
+            Nothing -> False
+      in HS.div
+        [
             HSA.class "control-background"
             , HSA.css
                 [ Css.padding (Css.rem 1)
                 , Css.borderRadius (Css.rem 0.5)
                 , Css.maxWidth (Css.px 400)
+                , (if shouldDisplay
+                    then Css.display Css.block
+                    else Css.display Css.none)
                 ]
         ]
-        [ HS.text (messageDisplay) ]
-
-messageDisplay : String
-messageDisplay
-    = "Click to start tutorial" 
+        [ message ]

--- a/src/Tutorial.elm
+++ b/src/Tutorial.elm
@@ -18,36 +18,43 @@ import Tutorial.Sequence as TS
 import Space
 import SpaceCommand as SC
 
+{-| State for tutorial. -}
 type alias Model
     = { sequence : TS.Sequence }
 
+{-| Starting state for tutorial. -}
 init : Model
 init = { sequence = TS.init }
 
+{-| Convenient helper to update sequence. -}
 modelLiftSequence
     : (TS.Sequence -> TS.Sequence)
    -> (Model -> Model)
 modelLiftSequence f model
     = { model | sequence = f model.sequence }
 
+{-| Combined model for tutorial and space. -}
 type alias WrapModel
     = {
         space : Space.Model
       , tutorial : Model
     }
 
+{-| Convenient helper to update tutorial state. -}
 wrapLiftTutorial
     : (Model -> Model)
    -> (WrapModel -> WrapModel)
 wrapLiftTutorial f model
     = { model | tutorial = f model.tutorial }
 
+{-| Combined starting state for tutorial and space. -}
 wrapInit : WrapModel
 wrapInit = {
         space = SC.init
       , tutorial = init
     }
 
+{-| View for the tutorial element shown in the header. -}
 view : Model -> HS.Html Message
 view model
     = let
@@ -73,13 +80,19 @@ view model
         ]
         [ message ]
 
+{-| Message for tutorial. -}
 type Message
     = Advance
 
+{-| Combined message for tutorial and space. -}
 type WrapMessage
     = SpaceMessage SC.Message
     | TutorialMessage Message
 
+{-| Update for tutorial messages.
+    This gets to see the whole model so that tutorial steps can modify
+    the state to guide interactions.
+ -}
 update : Message -> WrapModel -> WrapModel
 update message
     = case message of

--- a/src/Tutorial/Sequence.elm
+++ b/src/Tutorial/Sequence.elm
@@ -4,20 +4,38 @@ module Tutorial.Sequence exposing (
       , getCurrent
       , getMessage
       , advance
+      , StepAction(..)
     )
 
 import Html.Styled as HS
 import Html.Styled.Attributes as HSA
 
+import Space
+import Space.Content as Content
+
+{-| A sequence of steps in the tutorial. -}
 type alias Sequence = List Step
 
+{-| A single step in the tutorial. -}
 type alias Step
-    = { message : HS.Html () }
+    = {
+        message : HS.Html ()
+      , action : StepAction
+    }
+
+{-| Ways the tutorial can modify Space.Model. -}
+type StepAction
+    = NoAction
+    | ModifySpace (Space.Model -> Space.Model)
+    | RestoreFromCache
+
 
 init : Sequence
 init
     = [
-        { message = HS.text "Click to start tutorial" }
+        { message = HS.text "Click to start tutorial"
+        , action = RestoreFromCache
+        }
       , { message = HS.span []
             [ HS.text "These fractals come from "
             , HS.a
@@ -27,6 +45,28 @@ init
               ++ " or click this block to continue."
               )
             ]
+        , action = NoAction
+        }
+      , { message = HS.text ("This red frame represents an iteration."
+          ++ " Let's just look at one for now."
+          ++ " The red frame is the image of the thin black reference frame"
+          ++ " under a function."
+        )
+        , action = ModifySpace (\spaceModel ->
+            let
+                oldIterMode = spaceModel.iterMode
+                -- Drop all but the first IterFrame
+                idsToDrop = Maybe.withDefault []
+                    (List.tail (Content.getIterFrameIDs spaceModel.baseContents))
+                newContent = List.foldr Content.drop spaceModel.baseContents idsToDrop
+            in { spaceModel |
+                baseContents = newContent
+              , iterMode = { oldIterMode |
+                  depth = 0
+                , showIterFrames = True
+              }
+            }
+          )
         }
       ]
 

--- a/src/Tutorial/Sequence.elm
+++ b/src/Tutorial/Sequence.elm
@@ -68,6 +68,21 @@ init
             }
           )
         }
+      , { message = HS.text ("Now let's apply the function to the base shape once."
+          ++ " Notice how the new shape fits inside the red frame in the same way the base shape fits"
+          ++ " inside the thin black reference frame."
+          )
+        , action = ModifySpace (\spaceModel ->
+            let
+                oldIterMode = spaceModel.iterMode
+                newIterMode = { oldIterMode |
+                      depth = 1
+                  }
+            in { spaceModel |
+                iterMode = newIterMode
+            }
+          )
+        }
       ]
 
 getCurrent : Sequence -> Maybe Step

--- a/src/Tutorial/Sequence.elm
+++ b/src/Tutorial/Sequence.elm
@@ -3,6 +3,7 @@ module Tutorial.Sequence exposing (
       , init
       , getCurrent
       , getMessage
+      , advance
     )
 
 import Html.Styled as HS
@@ -15,6 +16,7 @@ init : Sequence
 init
     = [
         "Click to start tutorial"
+      , "These fractals come from Iteration Function Systems."
     ]
 
 getCurrent : Sequence -> Maybe Step
@@ -24,3 +26,10 @@ getCurrent sequence
 getMessage : Step -> HS.Html msg
 getMessage item
     = HS.text item
+
+advance : Sequence -> Sequence
+advance sequence
+    = case List.tail sequence of
+        Nothing -> init
+        Just [] -> init
+        Just rest -> rest

--- a/src/Tutorial/Sequence.elm
+++ b/src/Tutorial/Sequence.elm
@@ -72,16 +72,29 @@ init
           ++ " Notice how the new shape fits inside the red frame in the same way the base shape fits"
           ++ " inside the thin black reference frame."
           )
-        , action = ModifySpace (\spaceModel ->
-            let
-                oldIterMode = spaceModel.iterMode
-                newIterMode = { oldIterMode |
-                      depth = 1
-                  }
-            in { spaceModel |
-                iterMode = newIterMode
-            }
+        , action = ModifySpace (Space.setIterationDepth 1)
+        }
+      , { message = HS.text ("The knobs on the red frame let you modify the function."
+          ++ " The grey knob lets you move the center offset."
+          ++ " Give it a try!"
           )
+        , action = NoAction
+        }
+      , { message = HS.text ("The cyan knob lets you change the rotation angle."
+          ++ " Give it a spin!"
+          )
+        , action = NoAction
+        }
+      , { message = HS.text ("The yellow knob lets you change the scale."
+          ++ " Try making it bigger and smaller!"
+          )
+        , action = NoAction
+        }
+      , { message = HS.text ("The magenta knob lets you change how much the function stretches in one direction"
+          ++ " while keeping the other direction the same size. It also lets you change the skew,"
+          ++ " making right angles come out of the function at a slant."
+          )
+        , action = NoAction
         }
       ]
 

--- a/src/Tutorial/Sequence.elm
+++ b/src/Tutorial/Sequence.elm
@@ -35,7 +35,7 @@ init : Sequence
 init
     = [
         { message = HS.text "Click to start tutorial"
-        , action = RestoreFromCache
+        , action = NoAction
         }
       , { message = HS.span []
             [ HS.text "These fractals come from "
@@ -132,6 +132,9 @@ init
           ++ " Once it starts looking like a fractal, play with the frames again!"
           ++ " The way your changes affect the fractal might surprise you."
           )
+        , action = NoAction
+      }
+      , { message = HS.text ("That's all for this tutorial. Thanks for following along! If you want to start it again, just click here.")
         , action = NoAction
       }
       ]

--- a/src/Tutorial/Sequence.elm
+++ b/src/Tutorial/Sequence.elm
@@ -110,6 +110,30 @@ init
           )
         , action = RestoreHiddenContent
         }
+      , { message = HS.text ("Changing one function changes the shapes created by every frame, because at each layer"
+          ++ " each function takes all the shapes from the previous layer as input."
+          )
+        , action = NoAction
+        }
+      , { message = HS.text ("Let's add another iteration."
+          ++ " Change one of the functions again, and watch the shapes that change."
+          )
+        , action = ModifySpace (Space.setIterationDepth 3)
+      }
+      , { message = HS.text ("You might expect the image to just become randomly messy as you add more iterations."
+          ++ " However, under the right conditions, the image will converge to a pattern determined by the functions,"
+          ++ " not the initial shape."
+          )
+        , action = NoAction
+      }
+      , { message = HS.text ("Click the + on the sidebar under \"maximum iteration depth\" to add more iterations."
+          ++ " (Stop if you notice the page slow down."
+          ++ " This app doesn't currently prevent you from adding more shapes than your computer can handle.)"
+          ++ " Once it starts looking like a fractal, play with the frames again!"
+          ++ " The way your changes affect the fractal might surprise you."
+          )
+        , action = NoAction
+      }
       ]
 
 getCurrent : Sequence -> Maybe Step

--- a/src/Tutorial/Sequence.elm
+++ b/src/Tutorial/Sequence.elm
@@ -28,6 +28,7 @@ type StepAction
     = NoAction
     | ModifySpace (Space.Model -> Space.Model)
     | RestoreFromCache
+    | RestoreHiddenContent
 
 
 init : Sequence
@@ -41,16 +42,16 @@ init
             , HS.a
                 [ HSA.href "https://en.wikipedia.org/wiki/Iterated_function_system" ]
                 [ HS.text "iterated function systems" ]
-            , HS.text (". Click the link to read about them on Wikipedia,"
-              ++ " or click this block to continue."
+            , HS.text (". Click the link to read about them on Wikipedia."
+              ++ " Every time you're ready to continue with the next tutorial step, click this block."
               )
             ]
         , action = NoAction
         }
       , { message = HS.text ("This red frame represents an iteration."
           ++ " Let's just look at one for now."
-          ++ " The red frame is the image of the thin black reference frame"
-          ++ " under a function."
+          ++ " If you feed the thin black reference frame into the iteration function,"
+          ++ " you get the red frame as the output."
         )
         , action = ModifySpace (\spaceModel ->
             let
@@ -101,6 +102,13 @@ init
           ++ " Every change that happens to the first new shape happens to the second new shape doubled."
           )
         , action = ModifySpace (Space.setIterationDepth 2)
+        }
+      , { message = HS.text ("Now it's time to use multiple iteration functions at once."
+          ++ " Each function creates its own new shape at each layer."
+          ++ " Then for the next layer, each function takes all the shapes from the previous layer as input."
+          ++ " Spend some time playing with the functions, and watch how the shapes in the second layer change."
+          )
+        , action = RestoreHiddenContent
         }
       ]
 

--- a/src/Tutorial/Sequence.elm
+++ b/src/Tutorial/Sequence.elm
@@ -27,7 +27,6 @@ type alias Step
 type StepAction
     = NoAction
     | ModifySpace (Space.Model -> Space.Model)
-    | RestoreFromCache
     | RestoreHiddenContent
 
 

--- a/src/Tutorial/Sequence.elm
+++ b/src/Tutorial/Sequence.elm
@@ -7,25 +7,36 @@ module Tutorial.Sequence exposing (
     )
 
 import Html.Styled as HS
+import Html.Styled.Attributes as HSA
 
 type alias Sequence = List Step
 
-type alias Step = String
+type alias Step
+    = { message : HS.Html () }
 
 init : Sequence
 init
     = [
-        "Click to start tutorial"
-      , "These fractals come from Iteration Function Systems."
-    ]
+        { message = HS.text "Click to start tutorial" }
+      , { message = HS.span []
+            [ HS.text "These fractals come from "
+            , HS.a
+                [ HSA.href "https://en.wikipedia.org/wiki/Iterated_function_system" ]
+                [ HS.text "iterated function systems" ]
+            , HS.text (". Click the link to read about them on Wikipedia,"
+              ++ " or click this block to continue."
+              )
+            ]
+        }
+      ]
 
 getCurrent : Sequence -> Maybe Step
 getCurrent sequence
     = List.head sequence
 
-getMessage : Step -> HS.Html msg
+getMessage : Step -> HS.Html ()
 getMessage item
-    = HS.text item
+    = item.message
 
 advance : Sequence -> Sequence
 advance sequence

--- a/src/Tutorial/Sequence.elm
+++ b/src/Tutorial/Sequence.elm
@@ -96,6 +96,12 @@ init
           )
         , action = NoAction
         }
+      , { message = HS.text ("You probably noticed how the first new shape changes as you change the function."
+          ++ " Now let's apply the function again. Play with the knobs and watch the second new shape change."
+          ++ " Every change that happens to the first new shape happens to the second new shape doubled."
+          )
+        , action = ModifySpace (Space.setIterationDepth 2)
+        }
       ]
 
 getCurrent : Sequence -> Maybe Step

--- a/src/Tutorial/Sequence.elm
+++ b/src/Tutorial/Sequence.elm
@@ -1,0 +1,26 @@
+module Tutorial.Sequence exposing (
+        Sequence
+      , init
+      , getCurrent
+      , getMessage
+    )
+
+import Html.Styled as HS
+
+type alias Sequence = List Step
+
+type alias Step = String
+
+init : Sequence
+init
+    = [
+        "Click to start tutorial"
+    ]
+
+getCurrent : Sequence -> Maybe Step
+getCurrent sequence
+    = List.head sequence
+
+getMessage : Step -> HS.Html msg
+getMessage item
+    = HS.text item


### PR DESCRIPTION
This adds a basic tutorial shown in buttons in the top right, which can also update the space state. Users are walked through manipulating one iteration function first, then multiple at a time. The iteration frames are hidden and then restored to what they were before, so it should be usable when started from any configuration, including something custom.

Some things considered but left out for now for the sake of getting something done:

- Indicators such as arrows pointing to the knobs mentioned in the steps.
- Automatically advancing certain steps when the user takes the indicated action.

This could be improved upon in future, but for now I'll say this resolves #4.