### PR TITLE
Add undo & redo

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -11,6 +11,7 @@
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",
             "elm/json": "1.1.3",
+            "elm-community/undo-redo": "3.0.0",
             "justgook/alt-linear-algebra": "2.0.0",
             "mpizenberg/elm-pointer-events": "4.0.2",
             "rtfeldman/elm-css": "18.0.0"

--- a/src/Command.elm
+++ b/src/Command.elm
@@ -97,8 +97,7 @@ update msg model =
                         })
                         (getIterFrameIDtoDrop model)
                 else if change == 1
-                -- Iterframes are last in the list of baseContents, so just append a new one
-                then Space.addIterFrame (getNewIterFrameID model) (.defaultIterFrame) model
+                then Space.addIterFrameNew (getNewIterFrameID model) (.defaultIterFrame) model
                 else model
         Reset whichStart
             -> Start.get whichStart

--- a/src/Command.elm
+++ b/src/Command.elm
@@ -11,6 +11,7 @@ import Css
 import List
 import Maybe
 import Svg.Styled as S
+import UndoList as U
 
 import Space
 import Space.Content as Content
@@ -57,7 +58,7 @@ viewBar {iterMode, baseContents}
         ++ incrementer
             { incrementerDefaults | label = "# iteration frames" , min = Just 0}
             ChangeNumIterFrames
-            (Content.numIterFrames baseContents)
+            (Content.numIterFrames baseContents.present)
         ++ iterFrameKey iterMode.showIterFrames
 
 layerVisibilityControls : List (HS.Html Message)
@@ -90,7 +91,9 @@ update msg model =
                 then Maybe.withDefault model <|
                     Maybe.map
                         (\iterFrameIDtoDrop -> { model |
-                            baseContents = Content.drop iterFrameIDtoDrop model.baseContents
+                            baseContents = U.new
+                                (Content.drop iterFrameIDtoDrop model.baseContents.present)
+                                model.baseContents
                         })
                         (getIterFrameIDtoDrop model)
                 else if change == 1
@@ -113,7 +116,7 @@ update msg model =
  -}
 getIterFrameIDtoDrop : Space.Model -> Maybe ID.TreeID
 getIterFrameIDtoDrop {baseContents}
-    = List.head <| List.reverse <| Content.getIterFrameIDs baseContents
+    = List.head <| List.reverse <| Content.getIterFrameIDs baseContents.present
 
 {-| Get an ID for a new IterFrame to add to the baseContents.
 
@@ -123,7 +126,7 @@ getIterFrameIDtoDrop {baseContents}
  -}
 getNewIterFrameID : Space.Model -> ID.TreeID
 getNewIterFrameID {baseContents}
-    = ID.Trunk <| "f" ++ String.fromInt (1 + Content.numIterFrames baseContents)
+    = ID.Trunk <| "f" ++ String.fromInt (1 + Content.numIterFrames baseContents.present)
 
 iterFrameKey
     : Bool

--- a/src/Command.elm
+++ b/src/Command.elm
@@ -3,6 +3,7 @@ module Command exposing (
         Message(..)
       , viewBar
       , update
+      , subscriptions
     )
 
 import Html.Styled as HS
@@ -26,6 +27,7 @@ import Command.Components exposing (
       , textButtonGroup
       , commandLabel
     )
+import Command.Keyboard as Keyboard
 
 {-| Interactions with the command controls outside the drawing space -}
 type Message
@@ -158,3 +160,6 @@ iterFrameKey showIterFrames
                 ]
         ]
         else []
+
+subscriptions : Sub Message
+subscriptions = Sub.map UndoList Keyboard.undoRedoSubscriptions

--- a/src/Command/Keyboard.elm
+++ b/src/Command/Keyboard.elm
@@ -1,0 +1,41 @@
+module Command.Keyboard exposing (
+        undoRedoSubscriptions
+    )
+
+import Browser.Events
+import Json.Decode as JD
+import UndoList as U
+
+{-| Subscribe to Ctrl+Z for undo and Ctrl+Shift+Z for redo. -}
+undoRedoSubscriptions : Sub (U.Msg ())
+undoRedoSubscriptions = Browser.Events.onKeyDown undoRedoKeyDecoder
+
+undoRedoKeyDecoder : JD.Decoder (U.Msg ())
+undoRedoKeyDecoder = JD.map
+    (\isShiftOn -> if isShiftOn then U.Redo else U.Undo)
+    <| JD.andThen (always <| JD.field "shiftKey" JD.bool) (ctrlLetterDecoder "z")
+
+letterDecoder : String -> JD.Decoder ()
+letterDecoder l = JD.andThen
+    (\key ->
+        if String.toLower key == l then
+            JD.succeed ()
+        else
+            JD.fail "letter mismatch"
+    )
+    (JD.field "key" JD.string)
+
+ctrlDecoder : JD.Decoder ()
+ctrlDecoder = JD.andThen
+    (\ctrl ->
+        if ctrl then
+            JD.succeed ()
+        else
+            JD.fail "not ctrl"
+    )
+    (JD.field "ctrlKey" JD.bool)
+
+ctrlLetterDecoder : String -> JD.Decoder ()
+ctrlLetterDecoder l = JD.andThen
+    (always <| letterDecoder l)
+    ctrlDecoder

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -9,10 +9,11 @@ import SpaceCommand as SC
 import Tutorial
 
 main : Program () Tutorial.WrapModel Tutorial.WrapMessage
-main = B.sandbox {
-        init = Tutorial.wrapInit
+main = B.element {
+        init = \_ -> (Tutorial.wrapInit, Cmd.none)
       , view = HS.toUnstyled << viewWithHeaderFooter
-      , update = update
+      , update = \msg model -> (update msg model, Cmd.none)
+      , subscriptions = \_ -> Sub.map Tutorial.SpaceMessage SC.subscriptions
     }
 
 

--- a/src/Space.elm
+++ b/src/Space.elm
@@ -203,8 +203,15 @@ updatePtrOnSpace ptrUpd mdl
                 transformer
                 mdl.interact.pointer
                 ptrUpd
+
+        {- Only add to the undo stack when first turning on.
+           This saves the state from before the pointer starts moving to the stack.
+           While in motion, only the present state is updated. -}
+        lifter = if Pointer.isTurningOn mdl.interact.pointer newPointerState
+            then liftBaseContentsNew
+            else liftBaseContents
     in
-        liftBaseContents (List.map mungeContent)
+        lifter (List.map mungeContent)
             <| liftInteract (updatePointer <| always newPointerState) mdl
 
 {-| Update the model when a content is selected. -}

--- a/src/Space.elm
+++ b/src/Space.elm
@@ -11,7 +11,6 @@ module Space exposing (
     )
 
 import Html.Styled as HS
-import Css
 import Svg.Styled as S
 import Svg.Styled.Attributes as A
 import Svg.Styled.Keyed as K

--- a/src/Space/Pointer.elm
+++ b/src/Space/Pointer.elm
@@ -6,6 +6,7 @@ module Space.Pointer exposing (
       , doDrag
       , emptyState
       , select
+      , isTurningOn
       , getPayload {- not currently in use, but useful for debugging -}
     )
 
@@ -150,3 +151,14 @@ select makeMsg target
     = List.map A.fromUnstyled <| [
         E.onDown <| always <| makeMsg target
     ]
+
+{-| Check whether a pointer just turned on.
+
+    Args: old state, new state
+ -}
+isTurningOn : State a -> State a -> Bool
+isTurningOn old new
+    = case (old, new) of
+        (Off _, Off _) -> False
+        (Off _, _) -> True
+        _ -> False

--- a/src/SpaceCommand.elm
+++ b/src/SpaceCommand.elm
@@ -3,6 +3,7 @@ module SpaceCommand exposing (
       , init
       , view
       , update
+      , subscriptions
     )
 
 import List
@@ -43,3 +44,6 @@ update message
     = case message of
         SpaceMessage msg -> Space.update msg
         CommandMessage msg -> Command.update msg
+
+subscriptions : Sub Message
+subscriptions = Sub.map CommandMessage Command.subscriptions

--- a/src/Tutorial.elm
+++ b/src/Tutorial.elm
@@ -13,6 +13,7 @@ import Html.Styled.Attributes as HSA
 import Html.Styled.Events as HSE
 import Css
 import Maybe
+import UndoList as U
 
 import Tutorial.Sequence as TS
 import Space
@@ -147,8 +148,8 @@ cacheAndModifySpace modifier model
         newCache = {
             hiddenContent = if isEmptyHiddenContent oldCache
                 then Just (List.filter
-                    (\content -> not <| List.member content newSpaceModel.baseContents)
-                    model.space.baseContents)
+                    (\content -> not <| List.member content newSpaceModel.baseContents.present)
+                    model.space.baseContents.present)
                 else oldCache.hiddenContent
           }
 
@@ -162,7 +163,9 @@ cacheAndModifySpace modifier model
 restoreHiddenContent : Cache -> Space.Model -> Space.Model
 restoreHiddenContent cache spaceModel =
     { spaceModel |
-        baseContents = spaceModel.baseContents ++ Maybe.withDefault [] cache.hiddenContent
+        baseContents = U.new
+            (spaceModel.baseContents.present ++ Maybe.withDefault [] cache.hiddenContent)
+            spaceModel.baseContents
     }
 
 {-| Reset the hidden content portion of the cache -}

--- a/src/Tutorial/Sequence.elm
+++ b/src/Tutorial/Sequence.elm
@@ -9,6 +9,7 @@ module Tutorial.Sequence exposing (
 
 import Html.Styled as HS
 import Html.Styled.Attributes as HSA
+import UndoList as U
 
 import Space
 import Space.Content as Content
@@ -57,10 +58,10 @@ init
                 oldIterMode = spaceModel.iterMode
                 -- Drop all but the first IterFrame
                 idsToDrop = Maybe.withDefault []
-                    (List.tail (Content.getIterFrameIDs spaceModel.baseContents))
-                newContent = List.foldr Content.drop spaceModel.baseContents idsToDrop
+                    (List.tail (Content.getIterFrameIDs spaceModel.baseContents.present))
+                newContent = List.foldr Content.drop spaceModel.baseContents.present idsToDrop
             in { spaceModel |
-                baseContents = newContent
+                baseContents = U.new newContent spaceModel.baseContents
               , iterMode = { oldIterMode |
                   depth = 0
                 , showIterFrames = True


### PR DESCRIPTION
This implements undo & redo using elm-community / undo-redo, fixing #12.

The only state that undo/redo will control is baseContents, because all the other pieces have to do with display aspects and are easily toggled. The base shape and the IterFrames are the things that have fine controls a user might want to manage with the undo stack.

Adding and removing IterFrames update the stack. Pointer events update the stack only when the pointer is first turned on, so that the state between mouse drags is saved without making the user undo through hundreds of intermediate points.

The command bar now has undo and redo buttons, and keybindings are wired up. Undo is Ctrl+Z, Redo is Ctrl+Shift+Z.