### PR TITLE
Improve mobile layout and usability

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -134,4 +134,13 @@ footer a {
     .header h1 {
         font-size: 0.9rem;
     }
+
+    footer {
+        font-size: 0.6rem;
+    }
+
+    footer p {
+        margin-top: 0.2rem;
+        margin-bottom: 0.2rem;
+    }
 }

--- a/public/style.css
+++ b/public/style.css
@@ -88,6 +88,10 @@ footer a {
     resize: none;
 }
 
+.hide-me {
+    display: none;
+}
+
 @media (max-width: 900px) {
     .space-container {
         margin: 5px;
@@ -120,5 +124,14 @@ footer a {
 @media (max-height: 432px) {
     .mobile-optional {
         display: none;
+    }
+
+    .header {
+        flex: 0 0 50px; /* Even smaller header in landscape */
+        position: absolute;
+    }
+
+    .header h1 {
+        font-size: 0.9rem;
     }
 }

--- a/public/style.css
+++ b/public/style.css
@@ -87,3 +87,32 @@ footer a {
     height: 6rem;
     resize: none;
 }
+
+@media (max-width: 900px) {
+    .space-container {
+        margin: 5px;
+    }
+
+    .command-bar {
+        flex: 0 0 200px; /* Narrower sidebar on mobile */
+        margin: 5px;
+        font-size: 0.8rem;
+    }
+
+    .command-bar button,
+    .command-bar select {
+        font-size: 0.8rem;
+        padding: 0.15rem 0.3rem;
+    }
+
+    .command-label {
+        margin-top: 0.4rem;
+        margin-bottom: 0.1rem;
+        font-size: 0.6rem;
+    }
+
+    .command-bar textarea {
+        width: 180px; /* Adjust for narrower sidebar */
+        font-size: 0.75rem;
+    }
+}

--- a/public/style.css
+++ b/public/style.css
@@ -3,6 +3,7 @@ body {
     margin: 0;
 }
 
+
 #inner-root {
     display: flex;
     flex-direction: column;
@@ -122,6 +123,13 @@ footer a {
 }
 
 @media (max-height: 432px) {
+    html, body {
+        overflow: hidden;
+        position: fixed;
+        width: 100%;
+        height: 100%;
+    }
+
     .mobile-optional {
         display: none;
     }

--- a/public/style.css
+++ b/public/style.css
@@ -116,3 +116,9 @@ footer a {
         font-size: 0.75rem;
     }
 }
+
+@media (max-height: 432px) {
+    .mobile-optional {
+        display: none;
+    }
+}

--- a/public/style.css
+++ b/public/style.css
@@ -26,7 +26,7 @@ body {
 }
 
 footer {
-    flex: 0 0 54px;
+    flex: 0 0 auto;
 }
 
 .space-container {
@@ -138,7 +138,7 @@ footer a {
     }
 
     .header {
-        flex: 0 0 50px; /* Even smaller header in landscape */
+        flex: none; /* Remove from flex flow */
         position: absolute;
     }
 

--- a/public/style.css
+++ b/public/style.css
@@ -122,14 +122,17 @@ footer a {
     }
 }
 
-@media (max-height: 432px) {
+/* Disable scrolling on touchscreen devices */
+@media (pointer: coarse) {
     html, body {
         overflow: hidden;
         position: fixed;
         width: 100%;
         height: 100%;
     }
+}
 
+@media (max-height: 432px) {
     .mobile-optional {
         display: none;
     }

--- a/src/Command.elm
+++ b/src/Command.elm
@@ -17,6 +17,7 @@ import Css
 import List
 import Maybe
 import Svg.Styled as S
+import Svg.Styled.Attributes as SSA
 import UndoList as U
 import Browser.Navigation as Nav
 
@@ -228,7 +229,7 @@ getNewIterFrameID {baseContents}
 iterFrameKey : List (HS.Html msg)
 iterFrameKey
     = [
-        commandLabel "Iteration Frame Controls"
+        commandLabel [HSA.class "mobile-optional"] "Iteration Frame Controls"
       , S.svg
             [
                 HSA.css
@@ -238,7 +239,8 @@ iterFrameKey
                       -- Correct for extra whitespace in the SVG
                       , Css.marginBottom (Css.px -20)
                     ],
-                HSA.height 110
+                HSA.height 110,
+                SSA.class "mobile-optional"
             ]
             [
                 IterFrame.showKey

--- a/src/Command/Components.elm
+++ b/src/Command/Components.elm
@@ -18,10 +18,13 @@ import Css
 import Json.Decode as JD
 
 {-| Common heading for command controls -}
-commandLabel : String -> HS.Html msg
-commandLabel text =
+commandLabel
+    : List (HS.Attribute msg)
+   -> String
+   -> HS.Html msg
+commandLabel attrs text =
     HS.h4
-        [ HSA.class "command-label" ]
+        ( HSA.class "command-label" :: attrs)
         [ HS.text text ]
 
 incrementer
@@ -31,7 +34,7 @@ incrementer
    -> List (HS.Html msg)
 incrementer settings sendIncrement current
     = [
-        commandLabel settings.label
+        commandLabel [] settings.label
       , HS.span [] [
             HS.button
                 (
@@ -111,7 +114,7 @@ toggle label sendToggle current
             = if current then "on" else "off"
     in
     [
-        commandLabel label
+        commandLabel [] label
       , HS.button [HSE.onClick sendToggle, pressed, style] [HS.text labelText]
     ]
 
@@ -125,7 +128,7 @@ choice label choices
         (labels, messages) = List.unzip choices
         (values, onChange) = onChangeDiscrete messages
     in [
-        commandLabel label
+        commandLabel [] label
       , HS.select [HSA.class "control-background", onChange]
             <| List.map2
                 (\val lbl ->
@@ -168,7 +171,7 @@ textButtonGroup
 textButtonGroup header buttons
     = [
         HS.div [ HSA.css [Css.marginTop (Css.px 10)] ]
-            (commandLabel header
+            (commandLabel [] header
                 :: List.map
                     (\(label, msg) ->
                         HS.button

--- a/src/Tutorial.elm
+++ b/src/Tutorial.elm
@@ -108,19 +108,20 @@ view model
         shouldDisplay = case current of
             Just _ -> True
             Nothing -> False
+        hideMe = if shouldDisplay
+            then []
+            else [HSA.class "hide-me"]
       in HS.div
-        [
+        ( hideMe ++ [
             HSA.class "control-background"
+          , HSA.class "mobile-optional"
           , HSA.css
                 [ Css.padding (Css.rem 1)
                 , Css.borderRadius (Css.rem 0.5)
                 , Css.maxWidth (Css.rem 80)
-                , (if shouldDisplay
-                    then Css.display Css.block
-                    else Css.display Css.none)
                 ]
           , HSE.onClick Advance
-        ]
+        ])
         -- map for type only
         [ HS.map (always Advance) message ]
 


### PR DESCRIPTION
Fixes #8

This PR addresses the poor usability on mobile devices by implementing responsive design improvements.

## Changes Made

 - Mobile-responsive layout: Added media queries for screens under 900px width
    - Reduced margins and spacing for better space utilization
    - Narrower command sidebar (200px) on mobile devices
    - Scaled down font sizes appropriately
 - Small screen optimizations: Added media query for screens under 432px height
    - Hide non-essential UI elements (tutorial, iteration frame controls key)
    - Make header absolute positioned to maximize content area
    - Reduce footer size to fit content
 - Touch device improvements:
    - Disable scrolling on touchscreen devices to prevent accidental navigation
    - Prevent viewport manipulation that could interfere with app interaction

## Notes

The command bar design is not perfect for mobile screens yet, but this provides a usable starting point to iterate from.

## Testing

Tested using the mobile UI simulator in Firefox dev tools. All of these were used in landscape mode.
 - Various mobile phones
 - iPad
 - Desktop browsers (no regression, some minor layout shifts thanks to reducing space taken by the footer)
